### PR TITLE
update backend functions for retrieving avatar

### DIFF
--- a/lib/backend/user_profile_api/user_profile_model.dart
+++ b/lib/backend/user_profile_api/user_profile_model.dart
@@ -1,5 +1,7 @@
+import 'dart:convert';
+
 class UserProfile {
-  final String id;
+  final String? id;
   final String? updatedAt;
   final String? username;
   final String? fullName;
@@ -7,7 +9,7 @@ class UserProfile {
   final String? email;
 
   UserProfile({
-    required this.id,
+    this.id,
     this.updatedAt,
     this.username,
     this.fullName,
@@ -35,5 +37,10 @@ class UserProfile {
       'avatar_url': avatarUrl,
       'email': email,
     };
+  }
+
+  @override
+  String toString() {
+    return const JsonEncoder.withIndent('  ').convert(toMap());
   }
 }


### PR DESCRIPTION
### Changes

1. Remove `required` for `user_id` for UserProfile creation. 
    - will enforce in backend logic manually.
2. Update `getAvatarUrl()` to use signed urls for private bucket.
    - No changes required on frontend.