### PR TITLE
Make AuthService non-static

### DIFF
--- a/integration_test/auth_service_test.dart
+++ b/integration_test/auth_service_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+import 'package:homebased_project/backend/auth_api/auth_service.dart';
+
+void main() {
+  late AuthService authService;
+  late SupabaseClient adminClient;
+  User? user;
+
+  setUpAll(() async {
+    await dotenv.load(fileName: ".env");
+
+    final supabaseUrl = dotenv.env['SUPABASE_URL']!;
+    final supabaseAnonKey = dotenv.env['SUPABASE_ANON_KEY']!;
+    final supabaseServiceRoleKey = dotenv.env['SUPABASE_SECRET_KEY']!;
+
+    // Initialize normal Supabase client (for user operations)
+    await Supabase.initialize(url: supabaseUrl, anonKey: supabaseAnonKey);
+
+    // Use that for your app logic
+    authService = AuthService(client: Supabase.instance.client);
+
+    // Create a separate admin client (for deleting test users)
+    adminClient = SupabaseClient(supabaseUrl, supabaseServiceRoleKey);
+  });
+
+  tearDownAll(() async {
+    if (user != null) {
+      try {
+        await adminClient.auth.admin.deleteUser(user!.id);
+        print('✅ Cleaned up test user ${user!.email}');
+      } catch (e) {
+        print('⚠️ Failed to delete test user: $e');
+      }
+    }
+  });
+
+  testWidgets('Sign up, sign in, sign out (integration)', (tester) async {
+    final email =
+        'test_integration_${DateTime.now().millisecondsSinceEpoch}@example.com';
+    const password = 'securepassword123';
+
+    // Clean up in case the test user already exists
+    try {
+      await authService.signInWithEmailPassword(
+        email: email,
+        password: password,
+      );
+      await authService.signOut();
+    } catch (_) {}
+
+    // Sign up
+    final signUpResponse = await authService.signUpWithEmailPassword(
+      email: email,
+      password: password,
+    );
+    expect(signUpResponse.user, isNotNull);
+    user = signUpResponse.user; // 👈 Assign here for cleanup later
+
+    // Sign in
+    final signInResponse = await authService.signInWithEmailPassword(
+      email: email,
+      password: password,
+    );
+    expect(signInResponse.user, isNotNull);
+
+    // Check current user
+    expect(authService.currentUser?.email, equals(email));
+
+    // Sign out
+    await authService.signOut();
+    expect(authService.currentUser, isNull);
+  });
+}

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -7,6 +7,8 @@ PODS:
     - FlutterMacOS
   - image_picker_ios (0.0.1):
     - Flutter
+  - integration_test (0.0.1):
+    - Flutter
   - package_info_plus (0.4.5):
     - Flutter
   - path_provider_foundation (0.0.1):
@@ -23,6 +25,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
+  - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
@@ -37,6 +40,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/geolocator_apple/darwin"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
+  integration_test:
+    :path: ".symlinks/plugins/integration_test/ios"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
@@ -51,6 +56,7 @@ SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
+  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7

--- a/lib/backend/auth_api/auth_service.dart
+++ b/lib/backend/auth_api/auth_service.dart
@@ -2,20 +2,17 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'package:homebased_project/backend/supabase_api/supabase_service.dart';
 
+/// Expose a single AuthService instance that uses the global supabase
+final authService = AuthService();
+
 class AuthService {
-  static SupabaseClient _supabase = supabase;
+  final SupabaseClient _supabase;
 
-  /// For testing: allow overriding the Supabase client
-  static void setClient(SupabaseClient client) {
-    _supabase = client;
-  }
-
-  static void resetClient() {
-    _supabase = supabase;
-  }
+  /// Default constructor uses the global supabase instance
+  AuthService({SupabaseClient? client}) : _supabase = client ?? supabase;
 
   /// Sign in user with email + password
-  static Future<AuthResponse> signInWithEmailPassword({
+  Future<AuthResponse> signInWithEmailPassword({
     required String email,
     required String password,
   }) async {
@@ -26,7 +23,7 @@ class AuthService {
   }
 
   /// Sign up user with email + password
-  static Future<AuthResponse> signUpWithEmailPassword({
+  Future<AuthResponse> signUpWithEmailPassword({
     required String email,
     required String password,
   }) async {
@@ -35,7 +32,6 @@ class AuthService {
         email: email,
         password: password,
       );
-
       return response;
     } catch (e, st) {
       print('Supabase sign up error: $e\n$st');
@@ -44,17 +40,16 @@ class AuthService {
   }
 
   /// Sign out user
-  static Future<void> signOut() async {
+  Future<void> signOut() async {
     await _supabase.auth.signOut();
   }
 
   /// Returns the current user (or null if logged out)
-  static User? get currentUser => _supabase.auth.currentUser;
+  User? get currentUser => _supabase.auth.currentUser;
 
   /// Returns the current user's Supabase UUID (or null if logged out)
-  static String? get currentUserId => _supabase.auth.currentUser?.id;
+  String? get currentUserId => _supabase.auth.currentUser?.id;
 
   /// Stream of auth state changes
-  static Stream<AuthState> get onAuthStateChange =>
-      _supabase.auth.onAuthStateChange;
+  Stream<AuthState> get onAuthStateChange => _supabase.auth.onAuthStateChange;
 }

--- a/lib/backend/business_profile_api/business_profile_service.dart
+++ b/lib/backend/business_profile_api/business_profile_service.dart
@@ -11,7 +11,7 @@ class BusinessProfileService {
   static final String bucket = dotenv.env['BUSINESS_PROFILE_BUCKET_PROD'] ?? '';
 
   static String get _currentUserId {
-    final id = AuthService.currentUserId;
+    final id = authService.currentUserId;
     if (id == null) throw Exception('No user is currently logged in.');
     return id;
   }

--- a/lib/backend/user_profile_api/user_profile_service.dart
+++ b/lib/backend/user_profile_api/user_profile_service.dart
@@ -11,7 +11,7 @@ class UserProfileService {
   static final String bucket = dotenv.env['USER_PROFILE_BUCKET_PROD'] ?? '';
 
   static String get _currentUserId {
-    final id = AuthService.currentUserId;
+    final id = authService.currentUserId;
     if (id == null) throw Exception('No user is currently logged in.');
     return id;
   }

--- a/lib/home_page/home_page.dart
+++ b/lib/home_page/home_page.dart
@@ -14,7 +14,7 @@ class _HomePageState extends State<HomePage> {
   int _selectedIndex = 1;
 
   void _logout() async {
-    await AuthService.signOut();
+    await authService.signOut();
 
     if (!mounted) return;
     Navigator.pushReplacement(

--- a/lib/login_page/login_page.dart
+++ b/lib/login_page/login_page.dart
@@ -24,7 +24,7 @@ class _LoginPageState extends State<LoginPage> {
   @override
   void initState() {
     super.initState();
-    _authStateSubscription = AuthService.onAuthStateChange.listen(
+    _authStateSubscription = authService.onAuthStateChange.listen(
       (data) {
         if (_redirecting) return;
         final session = data.session;
@@ -56,7 +56,7 @@ class _LoginPageState extends State<LoginPage> {
   Future<void> signInWithEmail() async {
     setState(() => _isLoading = true);
     try {
-      final res = await AuthService.signInWithEmailPassword(
+      final res = await authService.signInWithEmailPassword(
         email: _emailController.text.trim(),
         password: _passwordController.text.trim(),
       );

--- a/lib/signup_page/signup_page.dart
+++ b/lib/signup_page/signup_page.dart
@@ -28,7 +28,7 @@ class _SignupPageState extends State<SignupPage> {
     setState(() => _isLoading = true);
 
     try {
-      final res = await AuthService.signUpWithEmailPassword(
+      final res = await authService.signUpWithEmailPassword(
         email: _emailController.text.trim(),
         password: _passwordController.text.trim(),
       );

--- a/lib/views/map_view.dart
+++ b/lib/views/map_view.dart
@@ -3,7 +3,6 @@ import 'package:homebased_project/backend/business_profile_api/business_profile_
 import 'package:latlong2/latlong.dart';
 import 'package:homebased_project/backend/map_api/map_service.dart';
 
-
 // Test screen for multimarkermap
 class MultiMapScreen extends StatefulWidget {
   const MultiMapScreen({super.key});
@@ -47,23 +46,21 @@ class _MultiMapScreenState extends State<MultiMapScreen> {
     ),
   ];
 
-  // Sample initial center 
+  // Sample initial center
   final LatLng _sampleCenter = LatLng(1.3162, 103.7649);
-  
+
   // Sample callback function for when a marker is clicked in the map
   void _sampleCallback(BusinessProfile profile) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(profile.businessName)),
-    );
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(profile.businessName ?? 'No name')));
   }
 
   @override
   Widget build(BuildContext context) {
     // Test for MultiMarkerMap
     return Scaffold(
-      appBar: AppBar(
-        title: const Text("Multi Marker Map"),
-      ),
+      appBar: AppBar(title: const Text("Multi Marker Map")),
       body: MapService.getMultiMarkerMap(
         initialCenter: _sampleCenter,
         markerProfiles: _sampleProfiles,
@@ -72,7 +69,6 @@ class _MultiMapScreenState extends State<MultiMapScreen> {
     );
   }
 }
-
 
 // Test screen for singlemarkermap
 class SingleMapScreen extends StatefulWidget {
@@ -83,16 +79,14 @@ class SingleMapScreen extends StatefulWidget {
 }
 
 class _SingleMapScreenState extends State<SingleMapScreen> {
-  // Sample initial center 
+  // Sample initial center
   final LatLng _sampleCenter = LatLng(1.3162, 103.7649);
 
   @override
   Widget build(BuildContext context) {
     // Test for SingleMarkerMap
-   return Scaffold(
-      appBar: AppBar(
-        title: const Text("Single Marker Map"),
-      ),
+    return Scaffold(
+      appBar: AppBar(title: const Text("Single Marker Map")),
       body: MapService.getSingleMarkerMap(initialCenter: _sampleCenter),
     );
   }

--- a/lib/views/pages/profile_page.dart
+++ b/lib/views/pages/profile_page.dart
@@ -67,8 +67,8 @@ class _ProfilePageState extends State<ProfilePage> {
       debugPrint("⚠️ No user profile found. Creating default one...");
 
       final newProfile = UserProfile(
-        id: AuthService.currentUserId!,
-        email: AuthService.currentUser?.email,
+        id: authService.currentUserId!,
+        email: authService.currentUser?.email,
         username: 'Guest',
         avatarUrl: null,
         fullName: null,
@@ -151,7 +151,7 @@ class _ProfilePageState extends State<ProfilePage> {
       debugPrint("✏️ Updating username to $newUsername...");
       if (newUsername.isNotEmpty) {
         await UserProfileService.updateCurrentUserProfile(
-          UserProfile(id: AuthService.currentUserId!, username: newUsername),
+          UserProfile(id: authService.currentUserId!, username: newUsername),
         );
       }
       username = newUsername;

--- a/lib/views/widget_tree.dart
+++ b/lib/views/widget_tree.dart
@@ -17,7 +17,7 @@ class WidgetTree extends StatefulWidget {
 
 class _WidgetTreeState extends State<WidgetTree> {
   void _logout() async {
-    await AuthService.signOut();
+    await authService.signOut();
 
     if (!mounted) return;
     Navigator.pushReplacement(

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,0 +1,61 @@
+PODS:
+  - app_links (1.0.0):
+    - FlutterMacOS
+  - file_selector_macos (0.0.1):
+    - FlutterMacOS
+  - FlutterMacOS (1.0.0)
+  - geolocator_apple (1.2.0):
+    - Flutter
+    - FlutterMacOS
+  - package_info_plus (0.0.1):
+    - FlutterMacOS
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - url_launcher_macos (0.0.1):
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - app_links (from `Flutter/ephemeral/.symlinks/plugins/app_links/macos`)
+  - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
+  - FlutterMacOS (from `Flutter/ephemeral`)
+  - geolocator_apple (from `Flutter/ephemeral/.symlinks/plugins/geolocator_apple/darwin`)
+  - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
+  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
+
+EXTERNAL SOURCES:
+  app_links:
+    :path: Flutter/ephemeral/.symlinks/plugins/app_links/macos
+  file_selector_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+  geolocator_apple:
+    :path: Flutter/ephemeral/.symlinks/plugins/geolocator_apple/darwin
+  package_info_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
+  path_provider_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
+  shared_preferences_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
+
+SPEC CHECKSUMS:
+  app_links: afe860c55c7ef176cea7fb630a2b7d7736de591d
+  file_selector_macos: 6280b52b459ae6c590af5d78fc35c7267a3c4b31
+  FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
+  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
+  package_info_plus: f0052d280d17aa382b932f399edf32507174e870
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
+
+PODFILE CHECKSUM: 7eb978b976557c8c1cd717d8185ec483fd090a82
+
+COCOAPODS: 1.16.2

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -214,6 +214,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.2.1"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -244,6 +249,11 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
     source: sdk
@@ -424,6 +434,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1+1"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   intl:
     dependency: transitive
     description:
@@ -656,6 +671,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: "107d8be718f120bbba9dcd1e95e3bd325b1b4a4f07db64154635ba03f2567a0d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.3"
   proj4dart:
     dependency: transitive
     description:
@@ -821,6 +844,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.9.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -965,6 +996,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,8 @@ dev_dependencies:
     sdk: flutter
 
   flutter_lints: ^6.0.0
+  integration_test:
+    sdk: flutter
 
 # The following section is specific to Flutter packages.
 flutter:


### PR DESCRIPTION
### What 

1. Make AuthService non-static.
2. Swap all static AuthService usage with the global instance of `authService`.
    - Follow up: use `Provider` ?
3. integration tests for `auth_service.dart`.

### Why

1. Makes unit testing AuthService easier by enabling injection of AuthService instance.
2. Allows for easier integration testing.

### Testing

1. Manual testing done to ensure that app is still working:
    - user can sign up
    - user can log in
    - user can log out
2. Ran `flutter test` integration test.