### PR TITLE
update user_profile_service non-static and supabase instance hot swappable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ ios/Runner.xcodeproj/project.pbxproj
 ios/Runner.xcodeproj/xcuserdata/
 ios/Runner.xcworkspace/xcuserdata/
 
+# coverage
+coverage/

--- a/documentation/backend/user_profile_api.md
+++ b/documentation/backend/user_profile_api.md
@@ -20,7 +20,7 @@ Get profile by supabase id (unique user ID).
 
 #### Arguments
 
-- None
+- String: userId
 
 #### Returns
 
@@ -52,23 +52,36 @@ Updates the current user profile.
 
 ### 4. uploadAvatar
 
-Upload avatar image to Supabase storage and stores public URL in table
+Upload avatar image to Supabase storage and stores filepath in profiles table
 
 #### Arguments
 
 - imageFile: File
+- String: userId
 
 #### Returns
 
 - None
 
-### 5. getAvatarUrl
+### 5. deleteAvatar
+
+Delete avatar image from Supabase storage and removes filepath in profiles table
+
+#### Arguments
+
+- String: userId
+
+#### Returns
+
+- None
+
+### 6. getAvatarUrl
 
 Returns the current user's avatar URL from the profiles table (or null if none exists)
 
 #### Arguments
 
-- None
+- String: userId
 
 #### Returns
 

--- a/integration_test/user_profile_service_test.dart
+++ b/integration_test/user_profile_service_test.dart
@@ -1,0 +1,333 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:homebased_project/backend/auth_api/auth_service.dart';
+import 'package:homebased_project/backend/user_profile_api/user_profile_service.dart';
+import 'package:homebased_project/backend/user_profile_api/user_profile_model.dart';
+
+void main() {
+  late AuthService authService;
+  late UserProfileService userProfileService;
+  late SupabaseClient adminClient;
+  late String tableName;
+
+  User? userA;
+  User? userB;
+
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await dotenv.load(fileName: ".env");
+
+    final supabaseUrl = dotenv.env['SUPABASE_URL']!;
+    final supabaseAnonKey = dotenv.env['SUPABASE_ANON_KEY']!;
+    final supabaseServiceRoleKey = dotenv.env['SUPABASE_SECRET_KEY']!;
+    tableName = dotenv.env['USER_PROFILE_TABLE_STAGING']!;
+
+    await Supabase.initialize(url: supabaseUrl, anonKey: supabaseAnonKey);
+
+    authService = AuthService(client: Supabase.instance.client);
+    userProfileService = UserProfileService(
+      client: Supabase.instance.client,
+      isTest: true,
+    );
+
+    adminClient = SupabaseClient(supabaseUrl, supabaseServiceRoleKey);
+  });
+
+  group('e2e tests', () {
+    tearDownAll(() async {
+      final users = [userA, userB];
+      for (var user in users) {
+        if (user == null) continue;
+
+        try {
+          await adminClient.from(tableName).delete().eq('id', user.id);
+          print('✅ Deleted profile row for ${user.id}');
+        } catch (e) {
+          print('⚠️ Failed to delete profile row for ${user.id}: $e');
+        }
+
+        try {
+          await adminClient.auth.admin.deleteUser(user.id);
+          print('✅ Deleted auth user ${user.email}');
+        } catch (e) {
+          print('⚠️ Failed to delete auth user ${user.email}: $e');
+        }
+      }
+    });
+
+    testWidgets('UserProfileService end-to-end integration', (tester) async {
+      // --- 1️⃣ Sign up a new test user ---
+      final email =
+          'profile_test_${DateTime.now().millisecondsSinceEpoch}@example.com';
+      const password = 'strongpassword123';
+
+      final signUpResponse = await authService.signUpWithEmailPassword(
+        email: email,
+        password: password,
+      );
+      userA = signUpResponse.user;
+      expect(userA, isNotNull);
+
+      // --- 2️⃣ Insert initial profile via RPC ---
+      final initialProfile = UserProfile(
+        id: authService.currentUserId!,
+        email: userA!.email,
+        username: 'InitialUser',
+        fullName: 'Integration Test User',
+      );
+
+      await userProfileService.insertCurrentUserProfile(
+        initialProfile,
+        isTest: true,
+      );
+      final fetchedProfile = await userProfileService.getCurrentUserProfile(
+        authService.currentUserId!,
+      );
+      expect(fetchedProfile, isNotNull);
+      expect(fetchedProfile!.email, equals(email));
+
+      print('✅ Inserted and fetched user profile successfully.');
+
+      // --- 3️⃣ Update username + full name ---
+      final updatedProfile = UserProfile(
+        id: authService.currentUserId!,
+        username: 'UpdatedUser',
+        fullName: 'Updated Full Name',
+      );
+      await userProfileService.updateCurrentUserProfile(updatedProfile);
+
+      final updated = await userProfileService.getCurrentUserProfile(
+        authService.currentUserId!,
+      );
+      expect(updated!.username, equals('UpdatedUser'));
+      expect(updated.fullName, equals('Updated Full Name'));
+
+      print('✅ Updated user profile successfully.');
+
+      // --- 4️⃣ Upload avatar to Supabase storage ---
+      final tempDir = await getTemporaryDirectory();
+      final fakeImage = File('${tempDir.path}/fake_avatar.png');
+      await fakeImage.writeAsBytes(List<int>.filled(256, 42));
+
+      await userProfileService.uploadAvatar(
+        fakeImage,
+        authService.currentUserId!,
+      );
+
+      final withAvatar = await userProfileService.getCurrentUserProfile(
+        authService.currentUserId!,
+      );
+      expect(withAvatar!.avatarUrl, isNotNull);
+      print('✅ Uploaded avatar and stored file path: ${withAvatar.avatarUrl}');
+
+      // --- 5️⃣ Retrieve signed avatar URL ---
+      final signedUrl = await userProfileService.getAvatarUrl(
+        authService.currentUserId!,
+      );
+      expect(signedUrl, isNotNull);
+      expect(signedUrl!.startsWith('http'), true);
+      print('✅ Retrieved signed URL: $signedUrl');
+
+      // Cleanup: remove all files in user's own folder
+      await userProfileService.deleteAvatar(authService.currentUserId!);
+      print('✅ Cleaned up uploaded avatar files for userA');
+
+      // --- 6️⃣ Sign out cleanup ---
+      await authService.signOut();
+      expect(authService.currentUser, isNull);
+      print('✅ Signed out successfully.');
+    });
+  });
+
+  group('RLS enforcement tests', () {
+    setUpAll(() async {
+      // Sign up two test users
+      final timestamp = DateTime.now().millisecondsSinceEpoch;
+      final emailA = 'userA_$timestamp@example.com';
+      final emailB = 'userB_$timestamp@example.com';
+      const password = 'strongpassword123';
+
+      final signUpA = await authService.signUpWithEmailPassword(
+        email: emailA,
+        password: password,
+      );
+      userA = signUpA.user;
+      await authService.signOut();
+
+      final signUpB = await authService.signUpWithEmailPassword(
+        email: emailB,
+        password: password,
+      );
+      userB = signUpB.user;
+      await authService.signOut();
+
+      // Insert initial profiles for both users
+      await authService.signInWithEmailPassword(
+        email: emailA,
+        password: password,
+      );
+      await userProfileService.insertCurrentUserProfile(
+        UserProfile(id: userA!.id, email: userA!.email, username: 'UserA'),
+        isTest: true,
+      );
+      await authService.signOut();
+
+      await authService.signInWithEmailPassword(
+        email: emailB,
+        password: password,
+      );
+      await userProfileService.insertCurrentUserProfile(
+        UserProfile(id: userB!.id, email: userB!.email, username: 'UserB'),
+        isTest: true,
+      );
+      await authService.signOut();
+    });
+
+    tearDownAll(() async {
+      final users = [userA, userB];
+      for (var user in users) {
+        if (user == null) continue;
+
+        try {
+          await adminClient.from(tableName).delete().eq('id', user.id);
+          print('✅ Deleted profile row for ${user.id}');
+        } catch (e) {
+          print('⚠️ Failed to delete profile row for ${user.id}: $e');
+        }
+
+        try {
+          await adminClient.auth.admin.deleteUser(user.id);
+          print('✅ Deleted auth user ${user.email}');
+        } catch (e) {
+          print('⚠️ Failed to delete auth user ${user.email}: $e');
+        }
+      }
+    });
+
+    testWidgets('User A cannot read User B profile', (tester) async {
+      await authService.signInWithEmailPassword(
+        email: userA!.email!,
+        password: 'strongpassword123',
+      );
+
+      final result = await Supabase.instance.client
+          .from(tableName)
+          .select()
+          .eq('id', userB!.id)
+          .maybeSingle();
+
+      expect(result, isNull);
+      await authService.signOut();
+    });
+
+    testWidgets('User A cannot update User B profile', (tester) async {
+      await authService.signInWithEmailPassword(
+        email: userA!.email!,
+        password: 'strongpassword123',
+      );
+
+      try {
+        await userProfileService.updateCurrentUserProfile(
+          UserProfile(id: userB!.id, username: 'HackedByA'),
+        );
+      } catch (e) {
+        print('Caught expected error: $e');
+      }
+
+      final res = await adminClient
+          .from(tableName)
+          .select()
+          .eq('id', userB!.id)
+          .maybeSingle();
+
+      if (res != null) {
+        final profileB = UserProfile.fromMap(res);
+        expect(profileB.username, isNot('HackedByA'));
+      }
+
+      await authService.signOut();
+    });
+
+    testWidgets('User A cannot delete User B profile', (tester) async {
+      await authService.signInWithEmailPassword(
+        email: userA!.email!,
+        password: 'strongpassword123',
+      );
+
+      try {
+        await Supabase.instance.client
+            .from(tableName)
+            .delete()
+            .eq('id', userB!.id);
+        final res = await adminClient
+            .from(tableName)
+            .select()
+            .eq('id', userB!.id)
+            .maybeSingle();
+        expect(res, isNotNull);
+      } catch (e) {
+        print('Caught unexpected error: $e');
+      }
+
+      await authService.signOut();
+    });
+
+    testWidgets('User A cannot upload to User B storage folder', (
+      tester,
+    ) async {
+      await authService.signInWithEmailPassword(
+        email: userA!.email!,
+        password: 'strongpassword123',
+      );
+
+      final tempDir = await getTemporaryDirectory();
+      final fakeFile = File('${tempDir.path}/hack.png');
+      await fakeFile.writeAsBytes(List<int>.filled(256, 42));
+
+      final storage = Supabase.instance.client.storage.from('avatars-staging');
+      final path = '${userB!.id}/hack.png';
+
+      try {
+        await storage.upload(path, fakeFile);
+      } catch (e) {
+        print('Caught expected error: $e');
+        expect(
+          (e as StorageException).message,
+          contains("new row violates row-level security policy"),
+        );
+      }
+
+      final res = await adminClient.storage
+          .from('avatars-staging')
+          .list(path: userB!.id);
+
+      expect(res, isEmpty);
+
+      await authService.signOut();
+    });
+
+    //   testWidgets('User A cannot read User B storage files', (tester) async {
+    //     await authService.signInWithEmailPassword(
+    //       email: userA!.email!,
+    //       password: 'strongpassword123',
+    //     );
+
+    //     final storage = Supabase.instance.client.storage.from('avatars-staging');
+    //     final path = userB!.id;
+
+    //     try {
+    //       await storage.createSignedUrl(path, 60);
+    //       fail('User A should not be able to read User B storage file');
+    //     } catch (e) {
+    //       print('Caught expected error: $e');
+    //       expect(e.toString(), contains('Unauthorized'));
+    //     }
+
+    //     await authService.signOut();
+    //   });
+  });
+}

--- a/lib/backend/user_profile_api/user_profile_model.dart
+++ b/lib/backend/user_profile_api/user_profile_model.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 class UserProfile {
-  final String? id;
+  final String id;
   final String? updatedAt;
   final String? username;
   final String? fullName;
@@ -9,7 +9,7 @@ class UserProfile {
   final String? email;
 
   UserProfile({
-    this.id,
+    required this.id,
     this.updatedAt,
     this.username,
     this.fullName,

--- a/lib/signup_page/signup_page.dart
+++ b/lib/signup_page/signup_page.dart
@@ -38,7 +38,7 @@ class _SignupPageState extends State<SignupPage> {
 
         // Insert user profile
         final profile = UserProfile(id: res.user!.id, email: res.user!.email);
-        await UserProfileService.insertCurrentUserProfile(profile);
+        await userProfileService.insertCurrentUserProfile(profile);
 
         if (!mounted) return;
         Navigator.of(

--- a/lib/views/pages/profile_page.dart
+++ b/lib/views/pages/profile_page.dart
@@ -61,7 +61,9 @@ class _ProfilePageState extends State<ProfilePage> {
   Future<void> _loadProfileData() async {
     debugPrint("➡️ Starting _loadProfileData...");
 
-    UserProfile? userProfile = await userProfileService.getCurrentUserProfile();
+    UserProfile? userProfile = await userProfileService.getCurrentUserProfile(
+      authService.currentUserId!,
+    );
 
     if (userProfile == null) {
       debugPrint("⚠️ No user profile found. Creating default one...");
@@ -91,8 +93,10 @@ class _ProfilePageState extends State<ProfilePage> {
 
     // 🔑 Get signed URL
     String? signedUrl;
-    if (userProfile?.avatarUrl != null) {
-      signedUrl = await userProfileService.getAvatarUrl();
+    if (userProfile.avatarUrl != null) {
+      signedUrl = await userProfileService.getAvatarUrl(
+        authService.currentUserId!,
+      );
     }
 
     if (!mounted) return;
@@ -171,10 +175,12 @@ class _ProfilePageState extends State<ProfilePage> {
       try {
         debugPrint("🖼️ Uploading avatar...");
         final file = File(tempProfileImagePath!);
-        await userProfileService.uploadAvatar(file);
+        await userProfileService.uploadAvatar(file, authService.currentUserId!);
 
         // Get new signed URL right after upload
-        final newSignedUrl = await userProfileService.getAvatarUrl();
+        final newSignedUrl = await userProfileService.getAvatarUrl(
+          authService.currentUserId!,
+        );
 
         setState(() {
           profileImagePath = newSignedUrl;

--- a/lib/views/pages/profile_page.dart
+++ b/lib/views/pages/profile_page.dart
@@ -61,7 +61,7 @@ class _ProfilePageState extends State<ProfilePage> {
   Future<void> _loadProfileData() async {
     debugPrint("➡️ Starting _loadProfileData...");
 
-    UserProfile? userProfile = await UserProfileService.getCurrentUserProfile();
+    UserProfile? userProfile = await userProfileService.getCurrentUserProfile();
 
     if (userProfile == null) {
       debugPrint("⚠️ No user profile found. Creating default one...");
@@ -75,7 +75,7 @@ class _ProfilePageState extends State<ProfilePage> {
       );
 
       try {
-        await UserProfileService.insertCurrentUserProfile(newProfile);
+        await userProfileService.insertCurrentUserProfile(newProfile);
         debugPrint("✅ Inserted default profile for user: ${newProfile.id}");
         userProfile = newProfile;
       } catch (e, st) {
@@ -92,7 +92,7 @@ class _ProfilePageState extends State<ProfilePage> {
     // 🔑 Get signed URL
     String? signedUrl;
     if (userProfile?.avatarUrl != null) {
-      signedUrl = await UserProfileService.getAvatarUrl();
+      signedUrl = await userProfileService.getAvatarUrl();
     }
 
     if (!mounted) return;
@@ -150,7 +150,7 @@ class _ProfilePageState extends State<ProfilePage> {
     try {
       debugPrint("✏️ Updating username to $newUsername...");
       if (newUsername.isNotEmpty) {
-        await UserProfileService.updateCurrentUserProfile(
+        await userProfileService.updateCurrentUserProfile(
           UserProfile(id: authService.currentUserId!, username: newUsername),
         );
       }
@@ -171,10 +171,10 @@ class _ProfilePageState extends State<ProfilePage> {
       try {
         debugPrint("🖼️ Uploading avatar...");
         final file = File(tempProfileImagePath!);
-        await UserProfileService.uploadAvatar(file);
+        await userProfileService.uploadAvatar(file);
 
         // Get new signed URL right after upload
-        final newSignedUrl = await UserProfileService.getAvatarUrl();
+        final newSignedUrl = await userProfileService.getAvatarUrl();
 
         setState(() {
           profileImagePath = newSignedUrl;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -592,7 +592,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,10 +28,10 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
   flutter_lints: ^6.0.0
   integration_test:
     sdk: flutter
+  path_provider: ^2.1.5
 
 # The following section is specific to Flutter packages.
 flutter:


### PR DESCRIPTION
### What

1. Make `UserProfileService` a non-static class.
    - Enables dynamic instantiation of testing instances to reference staging environment for Supabase integration tests.
2. Make supabase instance hot-swappable.
3. Decouple `auth_service.dart` from `user_profile_service.dart`.
    - `user_profile_service.dart` methods requires front end to reference the current user id via `auth_service.dart`.
    - `profile_page.dart` has been updated where necessary.
4. Update frontend pages to use global `userProfileService` instance.
    - Might need to rethink how to handle instances.
5. `user_profile_model.dart` require `userId` for `UserProfile` model creation. 
6. Developed integration tests for `user_profile_service.dart`.

### Why

1. The changes enable easier testing to be done, paving the foundations for testing in CI/CD.
2. Usage of integration testing enable robust testing of RLS policies on supabase, ensuring that it works as expected.
3. Enables instantiating test instances to hit staging environment on Supabase for integration tests.

### Testing

1. Manual testing done to ensure app is still working:
    - user can log in.
    - user can sign up.
    - Pages are viewable.
2. Local testing via integration testing to ensure `user_profile_service.dart` methods and supabase RLS is working as expected.